### PR TITLE
Allows hook output

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -75,7 +75,11 @@ main() {
             do
                 scriptname=$(basename $file)
                 echo "BEGIN $scriptname"
-                eval "\"$file\""
+                if [[ "${AUTOHOOK_DEBUG-}" == '' ]]; then
+                  eval "\"$file\"" &>/dev/null
+                else
+                  eval "\"$file\""
+                fi
                 script_exit_code="$?"
                 if [[ "$script_exit_code" != 0 ]]
                 then

--- a/autohook.sh
+++ b/autohook.sh
@@ -75,9 +75,9 @@ main() {
             do
                 scriptname=$(basename $file)
                 echo "BEGIN $scriptname"
-                eval $file &> /dev/null
-                script_exit_code=$?
-                if [[ $script_exit_code != 0 ]]
+                eval "$file"
+                script_exit_code="$?"
+                if [[ "$script_exit_code" != 0 ]]
                 then
                   hook_exit_code=$script_exit_code
                 fi

--- a/autohook.sh
+++ b/autohook.sh
@@ -75,7 +75,7 @@ main() {
             do
                 scriptname=$(basename $file)
                 echo "BEGIN $scriptname"
-                eval "$file"
+                eval "\"$file\""
                 script_exit_code="$?"
                 if [[ "$script_exit_code" != 0 ]]
                 then


### PR DESCRIPTION
## Which issues are addressed?
Hook output was disabled. This made it impossible for hooks to inform users of what was happening and perhaps give them guidelines in case of errors.


## What's implemented?
It was enabled


## Why this implementation?
No other way


## Any caveats?
No.


## Any additional notes?
Nope!


## Checklist

- [x] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
