### PR TITLE
Allows re-installing

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -39,7 +39,7 @@ install() {
     for hook_type in "${hook_types[@]}"
     do
         hook_symlink="$hooks_dir/$hook_type"
-        ln -s $autohook_linktarget $hook_symlink
+        ln -sf $autohook_linktarget $hook_symlink
     done
 }
 


### PR DESCRIPTION
## Which issues are addressed?
When re-running `autohook install`, `ln` fails as the links already exist.


## What's implemented?
Added `-f flag to `ln` to allow overriding.


## Why this implementation?



## Any caveats?



## Any additional notes?



## Checklist

- [ ] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
