### PR TITLE
Update hooks to Git v2.24.3, and preserve stdin stream for those hooks that consume it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Security   in case of vulnerabilities.
 
 ### Added
 - Contributors link to main executable.
+- `AUTOHOOK_DEBUG` flag for debug output.
+- Hook output.
 
 ### Changed
 - Moved repo to Autohook org.
@@ -23,6 +25,10 @@ Security   in case of vulnerabilities.
 ### Removed
 - Author from main executable.
 - "Say Thanks" badge from README.
+
+### Fixed
+- Bug with file names containing spaces.
+- Bug with reinstallation.
 
 
 ## [2.2.1] - 2018-08-26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,30 @@
 # Autohook Changelog
 
 
+<!--
+Added      for new features.
+Changed    for changes in existing functionality.
+Deprecated for soon-to-be removed features.
+Removed    for now removed features.
+Fixed      for any bug fixes.
+Security   in case of vulnerabilities.
+-->
+
+
+## [Unreleased]
+
+### Added
+- Contributors link to main executable.
+
+### Changed
+- Moved repo to Autohook org.
+- Updated listed website to reflect said move
+
+### Removed
+- Author from main executable.
+- "Say Thanks" badge from README.
+
+
 ## [2.2.1] - 2018-08-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,13 +96,13 @@ Autohook is now, well, more auto. The new version is conceptually redesigned:
 - Initial release
 
 
-[Unreleased]: https://github.com/nkantar/Autohook/compare/2.2.1...HEAD
-[2.2.1]: https://github.com/nkantar/Autohook/compare/2.2.0...2.2.1
-[2.2.0]: https://github.com/nkantar/Autohook/compare/2.1.1...2.2.0
-[2.1.1]: https://github.com/nkantar/Autohook/compare/2.1.0...2.1.1
-[2.1.0]: https://github.com/nkantar/Autohook/compare/2.0.1...2.1.0
-[2.0.1]: https://github.com/nkantar/Autohook/compare/2.0.0...2.0.1
-[2.0.0]: https://github.com/nkantar/Autohook/compare/1.0.2...2.0.0
-[1.0.2]: https://github.com/nkantar/Autohook/compare/1.0.1...1.0.2
-[1.0.1]: https://github.com/nkantar/Autohook/compare/1.0.0...1.0.1
-[1.0.0]: https://github.com/nkantar/Autohook/releases/tag/1.0.0
+[Unreleased]: https://github.com/Autohook/Autohook/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/Autohook/Autohook/compare/2.2.0...2.2.1
+[2.2.0]: https://github.com/Autohook/Autohook/compare/2.1.1...2.2.0
+[2.1.1]: https://github.com/Autohook/Autohook/compare/2.1.0...2.1.1
+[2.1.0]: https://github.com/Autohook/Autohook/compare/2.0.1...2.1.0
+[2.0.1]: https://github.com/Autohook/Autohook/compare/2.0.0...2.0.1
+[2.0.0]: https://github.com/Autohook/Autohook/compare/1.0.2...2.0.0
+[1.0.2]: https://github.com/Autohook/Autohook/compare/1.0.1...1.0.2
+[1.0.1]: https://github.com/Autohook/Autohook/compare/1.0.0...1.0.1
+[1.0.0]: https://github.com/Autohook/Autohook/releases/tag/1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Security   in case of vulnerabilities.
 
 ## [Unreleased]
 
+
+## [2.3.0] - 2021-02-22
+
 ### Added
 - Contributors link to main executable.
 - `AUTOHOOK_DEBUG` flag for debug output.
@@ -96,7 +99,8 @@ Autohook is now, well, more auto. The new version is conceptually redesigned:
 - Initial release
 
 
-[Unreleased]: https://github.com/Autohook/Autohook/compare/2.2.1...HEAD
+[Unreleased]: https://github.com/Autohook/Autohook/compare/2.3.0...HEAD
+[2.3.0]: https://github.com/Autohook/Autohook/compare/2.2.1...2.3.0
 [2.2.1]: https://github.com/Autohook/Autohook/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/Autohook/Autohook/compare/2.1.1...2.2.0
 [2.1.1]: https://github.com/Autohook/Autohook/compare/2.1.0...2.1.1

--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 It consists of one script which acts as the entry point for all the hooks, and which runs scripts based on symlinks in appropriate directories.
 
-[![Say Thanks!](https://img.shields.io/badge/Say%20Thanks-!-1EAEDB.svg)](https://saythanks.io/to/nkantar)
-
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ You're done!
 
 ## Contributing
 
-Contributions of all sorts are welcome, be they bug reports, patches, or even just feedback. Creating a [new issue](https://github.com/nkantar/Autohook/issues/new 'New Issue') or [pull request](https://github.com/nkantar/Autohook/compare 'New Pull Request') is probably the best way to get started.
+Contributions of all sorts are welcome, be they bug reports, patches, or even just feedback. Creating a [new issue](https://github.com/Autohook/Autohook/issues/new 'New Issue') or [pull request](https://github.com/Autohook/Autohook/compare 'New Pull Request') is probably the best way to get started.
 
-Please note that this project is released with a [Contributor Code of Conduct](https://github.com/nkantar/Autohook/blob/master/CODE_OF_CONDUCT.md 'Autohook Code of Conduct'). By participating in this project you agree to abide by its terms.
+Please note that this project is released with a [Contributor Code of Conduct](https://github.com/Autohook/Autohook/blob/master/CODE_OF_CONDUCT.md 'Autohook Code of Conduct'). By participating in this project you agree to abide by its terms.
 
 
 ## License

--- a/autohook.sh
+++ b/autohook.sh
@@ -2,9 +2,9 @@
 
 # Autohook
 # A very, very small Git hook manager with focus on automation
-# Author:   Nik Kantar <http://nkantar.com>
-# Version:  2.1.1
-# Website:  https://github.com/nkantar/Autohook
+# Contributors:   https://github.com/Autohook/Autohook/graphs/contributors
+# Version:        2.1.1
+# Website:        https://github.com/Autohook/Autohook
 
 
 echo() {

--- a/autohook.sh
+++ b/autohook.sh
@@ -3,7 +3,7 @@
 # Autohook
 # A very, very small Git hook manager with focus on automation
 # Contributors:   https://github.com/Autohook/Autohook/graphs/contributors
-# Version:        2.1.1
+# Version:        2.3.0
 # Website:        https://github.com/Autohook/Autohook
 
 


### PR DESCRIPTION
## Which issues are addressed?

Fixed bitrot by adding support for newer hooks.  Preserve the stdin stream for hook scripts that consume it, such as the pre-receive hook.   Fixed the computation of the root directory of the repository for hooks that run on a Git server.

## What's implemented?

As above.

## Why this implementation?

The stdin stream as defined by the Git hook documentation is stored in a temporary file for those hooks that need it.  It's a straightforward implementation that cleans up after itself using a trap.  The implementation is simple and straightforward.

## Any caveats?

The stdout and stderr streams from the hook scripts are no longer redirected to /dev/null so that they can be consumed by automation that invokes Git.  This is an incompatible change.

## Any additional notes?

The code now differentiates between hooks that consume stdin and those that do not.

There are no tests for the original script so none were added for this change.  Testing was done interactively.

The documentation (README.md file) is still correct and required no changes.

## Checklist

- [X] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
