### PR TITLE
Specify full path for target to fix broken symlink error

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Here's the overview of steps:
 3. Put your scripts in `hooks/scripts/`.
 4. Make sure said scripts are executable (e.g., `chmod +x hooks/scripts/delete-pyc-files`, etc.).
 5. Make directories for your hook types (e.g., `mkdir -p hooks/post-checkout hooks/pre-commit`).
-6. Symlink your scripts to the correct directories, using numbers in symlink names to enforce execution order (e.g., `ln -s hooks/scripts/delete-pyc-files.sh hooks/post-checkout/01-delete-pyc-files`, etc.).
+6. Symlink your scripts to the correct directories, using numbers in symlink names to enforce execution order (e.g., `ln -s $PWD/hooks/scripts/delete-pyc-files.sh hooks/post-checkout/01-delete-pyc-files`, etc.).
 
 The result should be a tree that looks something like this:
 


### PR DESCRIPTION
First of all, thanks for the great work on a very handy tool :-) 

## Which issues are addressed?

I was setting it up on a repo by following steps in the README ([here](https://github.com/Autohook/Autohook#example)). Step 6 (create symlink) runs successfully (exit code 0), but running the git hook fails with exit code 127 due to a broken symlink

Steps to reproduce error (broken symlink):
1. `mkdir hooks/scripts`
2. Create script: `echo 'running tests' > hooks/scripts/unit-test`
3. Create symlink: `ln -s hooks/scripts/unit-test hooks/pre-commit/01-unit-test`
4. Check symlink `file -L hooks/pre-commit/01-unit-test` (this fails with exit code 127)

Suggested fix:
- For step 3, we could use a full path for the target: `ln -s $PWD/hooks/scripts/unit-test hooks/pre-commit/01-unit-test`

## What's implemented?

Update documentation

## Why this implementation?

-

## Any caveats?

Not a caveat, but a question: Would it be simpler if remove the `hooks/scripts` directory and directly specify any command we want to run in in `hooks/{hook-name}` directory? For example:

```sh
# in hooks/pre-commit/01-unit-test

# run the task
```

## Any additional notes?



## Checklist

- [x] Everything works.
- [x] Test are present and pass.
- [x] Documentation has been updated.
