### PR TITLE
Fix script to work within directory paths that contain whitespace

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -65,7 +65,7 @@ install() {
     for hook_type in "${hook_types[@]}" "${hook_types_stdin[@]}"
     do
         hook_symlink="$hooks_dir/$hook_type"
-        ln -sf $autohook_linktarget $hook_symlink
+        ln -sf $autohook_linktarget "$hook_symlink"
     done
 }
 
@@ -77,7 +77,7 @@ reads_stdin() {
 }
 
 main() {
-    calling_file=$(basename $0)
+    calling_file=$(basename "$0")
 
     if [[ $calling_file == "autohook.sh" ]]
     then
@@ -98,7 +98,7 @@ main() {
         number_of_symlinks="${#files[@]}"
         if [[ $number_of_symlinks == 1 ]]
         then
-            if [[ "$(basename ${files[0]})" == "*" ]]
+            if [[ "$(basename "${files[0]}")" == "*" ]]
             then
                 number_of_symlinks=0
             fi
@@ -113,7 +113,7 @@ main() {
             hook_exit_code=0
             for file in "${files[@]}"
             do
-                scriptname=$(basename $file)
+                scriptname=$(basename "$file")
                 echo "BEGIN $scriptname"
                 if reads_stdin "$calling_file"
                 then


### PR DESCRIPTION
## Which issues are addressed?

Previously, ther were issues with the script not working when directory paths contained whitespace:

```txt
/home/edwin/Repositories/Big Things/file/.git
```


## What's implemented?

This fixes that case by quoting where it is needed (to prevent Bash from word splitting)

## Why this implementation?

It's simplest.


## Any caveats?

No caveats.


## Checklist

- [x] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
