### PR TITLE
Issue #21:  Pass autohook.sh command line parameters on to the hook s…

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -166,9 +166,9 @@ main() {
       echo "BEGIN $scriptname"
 
       if reads_stdin "$hook_type"; then
-        "$file" < "$tmpfile"
+        "$file" "$@" < "$tmpfile"
       else
-        "$file"
+        "$file" "$@"
       fi
 
       script_exit_code="$?"


### PR DESCRIPTION


## Which issues are addressed?
#21 

## What's implemented?
Pass autohook.sh command line parameters on to the hook scripts.


## Why this implementation?
Obvious implementation to pass the main function's parameters on the command lines invoking the hook scripts.


## Any caveats?



## Any additional notes?



## Checklist

- [X] Everything works.
- [X] Test are present and pass.
- [N/A] Documentation has been updated.
