### PR TITLE
Issue #24:  All echo commands get redirected from stdout to stderr.

### DIFF
--- a/autohook.sh
+++ b/autohook.sh
@@ -9,12 +9,12 @@
 debugging=1
 debug() {
   if [[ $debugging -ne 0 ]]; then
-    builtin echo "[Autohook debug] $@"
+    builtin echo "[Autohook debug] $@" 1>&2
   fi
 }
 
 echo() {
-  builtin echo "[Autohook] $@"
+  builtin echo "[Autohook] $@" 1>&2
 }
 
 # Set up a temporary file and delete it automatically upon exit.


### PR DESCRIPTION
## Which issues are addressed?

All "echo" commands are redirected from stdout to stderr.

## What's implemented?

Added "1>&2" to the end of the builtin echo calls in the utility functions at the top.

## Why this implementation?

Every echo needs the same behavior.  The utility functions provide a place to abstract out the calls to write output that affect every message.

## Any caveats?

Possible compatibility issue with scripts that call Git and expect diagnostic messages to appear in a pipeline.

## Any additional notes?



## Checklist

- [x] Everything works.
- [ ] Test are present and pass.
- [ ] Documentation has been updated.
